### PR TITLE
Fix unescaped apostrophes in chat UI

### DIFF
--- a/components/Chat/Chat.tsx
+++ b/components/Chat/Chat.tsx
@@ -147,7 +147,7 @@ export const Chat: FC<Props> = memo(
               Welcome to Chatbot UI
             </div>
             <div className="text-center text-lg text-black dark:text-white">
-              <div className="mb-8">`Chatbot UI is an open source clone of OpenAI's ChatGPT UI.`</div>
+              <div className="mb-8">Chatbot UI is an open source clone of OpenAI&apos;s ChatGPT UI.</div>
               <div className="mb-2 font-bold">
                 Important: Chatbot UI is 100% unaffiliated with OpenAI.
               </div>

--- a/components/Chat/ChatInput.tsx
+++ b/components/Chat/ChatInput.tsx
@@ -363,7 +363,7 @@ export const ChatInput: FC<Props> = ({
         </a>
         .{' '}
         {t(
-          "Chatbot UI is an advanced chatbot kit for OpenAI's chat models aiming to mimic ChatGPT's interface and functionality.",
+          "Chatbot UI is an advanced chatbot kit for OpenAI&apos;s chat models aiming to mimic ChatGPT&apos;s interface and functionality.",
         )}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- fix lint error by escaping apostrophes in `Chat.tsx`
- escape apostrophes in `ChatInput.tsx` footer string

## Testing
- `npm run build` *(fails: Failed to fetch `Inter` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_686bc061528483218372259f53369e02